### PR TITLE
Replace double underscore with `this` for doc

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -121,7 +121,7 @@ For this example we will use record types, but "normal" classes will also work i
         inherit DbContext()
         
         [<DefaultValue>] val mutable blogs : DbSet<Blog>
-        member __.Blogs with get() = __.blogs and set v = __.blogs <- v
+        member this.Blogs with get() = this.blogs and set v = this.blogs <- v
 
         override __.OnConfiguring(options: DbContextOptionsBuilder) : unit =
             options.UseSqlite("Data Source=blogging.db") |> ignore


### PR DESCRIPTION
## Proposed Changes

The double underscore was previously used for discarding. Therefore, it is better to specify as `this` (or `x`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

