### PR TITLE
Adding DbSet/IQueryiable helpers to deal with EF Core async and nullable methods

### DIFF
--- a/docsSrc/How_Tos/Use_DbContextHelpers.md
+++ b/docsSrc/How_Tos/Use_DbContextHelpers.md
@@ -84,6 +84,45 @@ updateBlog { myBlog with Content = "Updated content" }
 
 ```
 
+We also have methods and functions for `DbSet`/`IQueryiable` to replace usage of `FirstOrDefault` and `FirstOrDefaultAsync`:
+
+
+```fsharp
+
+let queryingContext (ctx:MyContext) =
+    let allPosts = toListAsync ctx.Blogs |> Async.RunSynchronously
+
+    let firstBlog = 
+        match tryFirst ctx.Blogs with
+        | Some b -> b
+        | None -> failwithf "no blogs"
+
+    let filteredBlog = 
+        let maybeBlog = tryFilterFirst <@ fun x -> x.Title = "some title" @> ctx.Blogs
+        match maybeBlog with
+        | Some b -> b
+        | None -> failwithf "no blogs founded with the title"
+
+    let firstBlogLinq = 
+        match ctx.Blogs.TryFirst() with
+        | Some b -> b
+        | None -> failwithf "no blogs"
+
+    let filteredBlogLinq = 
+        match ctx.Blogs.TryFirst(fun x -> x.Title = "some title") with
+        | Some b -> b
+        | None -> failwithf "no blogs founded with the title"
+
+    let advancedQuery = query {
+            for b in ctx.Blogs do
+            where (b.Title = "My title" && b.Content = "Some content")
+            select b.Id
+        }
+        |> tryFirstAsync
+        |> Async.RunSynchronously
+
+```
+
 ## Async methods
 
 All methods in `EntityFrameworkCore.FSharp.DbContextHelpers` also have Async variants with support for `async { ... }` expressions

--- a/src/EFCore.FSharp/EFCore.FSharp.fsproj
+++ b/src/EFCore.FSharp/EFCore.FSharp.fsproj
@@ -39,8 +39,8 @@
     <Compile Include="Migrations\Design\FSharpMigrationsGenerator.fs" />
     <Compile Include="Migrations\Design\FSharpMigrationsScaffolder.fs" />
     <Compile Include="Extensions\ModelBuilderExtensions.fs" />
-    <Compile Include="EFCoreFSharpServices.fs" />
     <Compile Include="DbContextHelpers.fs" />
+    <Compile Include="EFCoreFSharpServices.fs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="build\**\*">

--- a/tests/EFCore.FSharp.Tests/DbContextHelperTests.fs
+++ b/tests/EFCore.FSharp.Tests/DbContextHelperTests.fs
@@ -112,3 +112,224 @@ let DbContextHelperTests =
             Expect.isNone found "Should be None"
         }
     ]
+
+[<Tests>]
+let DbSetTests =
+    testList "DbContextHelperTests dbSet tests" [
+
+        test "toListAsync should return a list of blogs" {
+            use ctx = createContext()
+            let blog = {
+                Id = (Guid.NewGuid())
+                Title = "My Title"
+                Content = "My original content"
+            }
+
+            addEntity ctx blog |> ignore
+            saveChanges ctx |> ignore
+
+            let result = toListAsync ctx.Blogs |> Async.RunSynchronously
+
+            Expect.equal [blog] result "Should be same"
+        }
+
+
+        test "tryFirstAsync should return the blog" {
+            use ctx = createContext()
+            let blog = {
+                Id = (Guid.NewGuid())
+                Title = "My Title"
+                Content = "My original content"
+            }
+
+            addEntity ctx blog |> ignore
+            saveChanges ctx |> ignore
+
+            let result = tryFirstAsync ctx.Blogs |> Async.RunSynchronously
+
+            let actual = Expect.wantSome result "should have one"
+            Expect.equal blog actual "Should be same"
+        }
+
+        test "tryFirstAsync should return None" {
+            use ctx = createContext()
+            let result = tryFirstAsync ctx.Blogs |> Async.RunSynchronously
+            Expect.isNone result "should have none"
+        }
+
+        test "tryFirst should return the blog" {
+            use ctx = createContext()
+            let blog = {
+                Id = (Guid.NewGuid())
+                Title = "My Title"
+                Content = "My original content"
+            }
+
+            addEntity ctx blog |> ignore
+            saveChanges ctx |> ignore
+
+            let result = tryFirst ctx.Blogs
+
+            let actual = Expect.wantSome result "should have one"
+            Expect.equal blog actual "Should be same"
+        }
+
+        test "tryFirst should return None" {
+            use ctx = createContext()
+            let result = tryFirst ctx.Blogs
+            Expect.isNone result "should have none"
+        }
+
+        test "tryFilterFirstAsync should return the blog" {
+            use ctx = createContext()
+            let id = Guid.NewGuid()
+            let blog = {
+                Id = id
+                Title = "My Title"
+                Content = "My original content"
+            }
+
+            addEntity ctx blog |> ignore
+            saveChanges ctx |> ignore
+
+            let result = tryFilterFirstAsync
+                             <@ fun x -> x.Id  = id @>
+                             ctx.Blogs
+                             |> Async.RunSynchronously
+
+            let actual = Expect.wantSome result "should have one"
+            Expect.equal blog actual "Should be same"
+        }
+
+        test "tryFilterFirstAsync should return None" {
+            use ctx = createContext()
+            let id = Guid.NewGuid()
+            let result = tryFilterFirstAsync
+                             <@ fun x -> x.Id  = id @>
+                             ctx.Blogs
+                             |> Async.RunSynchronously
+            Expect.isNone result "should have none"
+        }
+
+        test "tryFilterFirst should return the blog" {
+            use ctx = createContext()
+            let id = Guid.NewGuid()
+            let blog = {
+                Id = id
+                Title = "My Title"
+                Content = "My original content"
+            }
+
+            addEntity ctx blog |> ignore
+            saveChanges ctx |> ignore
+
+            let result = tryFilterFirst <@ fun x -> x.Id  = id @> ctx.Blogs
+
+            let actual = Expect.wantSome result "should have one"
+            Expect.equal blog actual "Should be same"
+        }
+
+        test "tryFilterFirst should return None" {
+            use ctx = createContext()
+            let id = Guid.NewGuid()
+            let result = tryFilterFirst <@ fun x -> x.Id  = id @> ctx.Blogs
+            Expect.isNone result "should have none"
+        }
+
+
+        test "TryFirstAsync extension should return the blog" {
+            use ctx = createContext()
+            let blog = {
+                Id = (Guid.NewGuid())
+                Title = "My Title"
+                Content = "My original content"
+            }
+
+            addEntity ctx blog |> ignore
+            saveChanges ctx |> ignore
+
+            let result = ctx.Blogs.TryFirstAsync() |> Async.RunSynchronously
+
+            let actual = Expect.wantSome result "should have one"
+            Expect.equal blog actual "Should be same"
+        }
+
+        test "TryFirstAsync extension should return None" {
+            use ctx = createContext()
+            let result = ctx.Blogs.TryFirstAsync() |> Async.RunSynchronously
+            Expect.isNone result "should have none"
+        }
+
+        test "TryFirst extension should return the blog" {
+            use ctx = createContext()
+            let blog = {
+                Id = (Guid.NewGuid())
+                Title = "My Title"
+                Content = "My original content"
+            }
+
+            addEntity ctx blog |> ignore
+            saveChanges ctx |> ignore
+
+            let result = ctx.Blogs.TryFirst()
+
+            let actual = Expect.wantSome result "should have one"
+            Expect.equal blog actual "Should be same"
+        }
+
+        test "TryFirst extension should return None" {
+            use ctx = createContext()
+            let result = ctx.Blogs.TryFirst()
+            Expect.isNone result "should have none"
+        }
+
+        test "TryFirstAsync extension with filter should return the blog" {
+            use ctx = createContext()
+            let id = Guid.NewGuid()
+            let blog = {
+                Id = id
+                Title = "My Title"
+                Content = "My original content"
+            }
+
+            addEntity ctx blog |> ignore
+            saveChanges ctx |> ignore
+
+            let result = ctx.Blogs.TryFirstAsync(fun x -> x.Id  = id) |> Async.RunSynchronously
+
+            let actual = Expect.wantSome result "should have one"
+            Expect.equal blog actual "Should be same"
+        }
+
+        test "TryFirstAsync extension with filter should return None" {
+            use ctx = createContext()
+            let id = Guid.NewGuid()
+            let result = ctx.Blogs.TryFirstAsync(fun x -> x.Id  = id) |> Async.RunSynchronously
+            Expect.isNone result "should have none"
+        }
+
+        test "TryFirst extension with filter should return the blog" {
+            use ctx = createContext()
+            let id = Guid.NewGuid()
+            let blog = {
+                Id = id
+                Title = "My Title"
+                Content = "My original content"
+            }
+
+            addEntity ctx blog |> ignore
+            saveChanges ctx |> ignore
+
+            let result = ctx.Blogs.TryFirst(fun x -> x.Id  = id)
+
+            let actual = Expect.wantSome result "should have one"
+            Expect.equal blog actual "Should be same"
+        }
+
+        test "TryFirst extension with filter should return None" {
+            use ctx = createContext()
+            let id = Guid.NewGuid()
+            let result = ctx.Blogs.TryFirst(fun x -> x.Id = id)
+            Expect.isNone result "should have none"
+        }
+    ]


### PR DESCRIPTION
## Proposed Changes

EF Core gives a lot of Linq extensions like `FirstOrDefaultAsync` and `ToListAsync`.
The problem with the `FirstOrDefault[Async]` is the fact that it could return `null` instead of option which the idiomatic  F# option.
So with this PR I'm adding some functions and methods to help to deal with this common cases.

## Types of changes

What types of changes does your code introduce to EFCore.FSharp?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] Build and tests pass locally
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added necessary documentation (if appropriate)
