### PR TITLE
Better extensions and more helpers

### DIFF
--- a/docsSrc/How_Tos/Querying_Options.md
+++ b/docsSrc/How_Tos/Querying_Options.md
@@ -40,14 +40,13 @@ type MyContext () =
         builder.RegisterOptionTypes() // enables option values for all entities
 
     override _.OnConfiguring(options: DbContextOptionsBuilder) : unit =
-           options.UseSqlite(
-              "Data Source=dbName.db",
-              (fun builder -> builder.UseFSharpTypes() |> ignore))
+           options.UseSqlite("Data Source=dbName.db")
+                  .UseFSharpTypes())
            |> ignore
 
 ```
 
-Note that the  `builder.UseFSharpTypes()` will exist independent of the database, the `UseSqlite` is just for the example. 
+Note that the  `.UseFSharpTypes()` will exist independent of the database, the `UseSqlite` is just for the example. 
 If you are using an SQL server with `UseSqlServer` or `UsePostgres` for Postgres, or any other database it will exist.
 
 ## Querying

--- a/src/EFCore.FSharp/DbContextHelpers.fs
+++ b/src/EFCore.FSharp/DbContextHelpers.fs
@@ -26,7 +26,7 @@ let tryFindEntityAsync<'a when 'a : not struct> (ctx: DbContext) (key: obj) =
     }
 
 /// Helper method for saving an updated record type
-let updateEntity (ctx: DbContext) (key: 'a -> obj) (entity : 'a when 'a : not struct) =
+let updateEntity (ctx: DbContext) (key: 'a -> 'b) (entity : 'a when 'a : not struct) =
     let currentEntity = findEntity<'a> ctx (key entity)
     ctx.Entry(currentEntity).CurrentValues.SetValues(entity :> obj)
     entity
@@ -44,42 +44,64 @@ let updateEntityRangeAsync  (ctx: DbContext) (key: 'a -> obj) (entities : 'a seq
         return updateEntityRange ctx key entities
     }
 
-let saveChanges (ctx: DbContext) =
+let saveChanges (ctx: #DbContext) =
     ctx.SaveChanges()
 
-let saveChangesAsync (ctx: DbContext) =
+let saveChanges' ctx  = saveChanges ctx |> ignore
+
+
+let saveChangesAsync (ctx: #DbContext) =
     async {
         return! ctx.SaveChangesAsync() |> Async.AwaitTask
     }
+let saveChangesAsync' ctx = saveChangesAsync ctx |> Async.Ignore
 
-let addEntity (ctx: DbContext) (entity : 'a when 'a : not struct) =
+
+let addEntity (ctx: #DbContext) (entity : 'a when 'a : not struct) =
     ctx.Set<'a>().Add entity
 
-let addEntityAsync (ctx: DbContext) (entity : 'a when 'a : not struct) =
+let addEntity' ctx entity =addEntity ctx entity |> ignore
+
+
+let addEntityAsync (ctx: #DbContext) (entity : 'a when 'a : not struct) =
     async {
         return! ctx.Set<'a>().AddAsync(entity) |> awaitValueTask
     }
+let addEntityAsync' ctx entity  = addEntityAsync ctx entity |> Async.Ignore
 
-let addEntityRange (ctx: DbContext) (entities : 'a seq when 'a : not struct) =
+
+let addEntityRange (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
     ctx.Set<'a>().AddRange entities
 
-let addEntityRangeAsync (ctx: DbContext) (entities : 'a seq when 'a : not struct) =
+let addEntityRange' (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
+    addEntityRange ctx entities |> ignore
+
+let addEntityRangeAsync (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
     async {
         return! ctx.Set<'a>().AddRangeAsync(entities) |> Async.AwaitTask
     }
+let addEntityRangeAsync' (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
+    addEntityRangeAsync ctx entities |> Async.Ignore
 
-let attachEntity (ctx: DbContext) (entity : 'a when 'a : not struct) =
+let attachEntity (ctx: #DbContext) (entity : 'a when 'a : not struct) =
     ctx.Set<'a>().Attach entity
+let attachEntity' (ctx: #DbContext) (entity : 'a when 'a : not struct) =
+    attachEntity ctx entity |> ignore
 
-let attachEntityRange (ctx: DbContext) (entities : 'a seq when 'a : not struct) =
+let attachEntityRange (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
     ctx.Set<'a>().AttachRange(entities)
+let attachEntityRange' (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
+    attachEntityRange ctx entities |> ignore
 
-let removeEntity (ctx: DbContext) (entity : 'a when 'a : not struct) =
+let removeEntity (ctx: #DbContext) (entity : 'a when 'a : not struct) =
     ctx.Set<'a>().Remove entity
+let removeEntity' (ctx: #DbContext) (entity : 'a when 'a : not struct) =
+    removeEntity ctx entity |> ignore
 
-let removeEntityRange (ctx: DbContext) (entities : 'a seq when 'a : not struct) =
+let removeEntityRange (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
     ctx.Set<'a>().RemoveRange(entities)
-
+let removeEntityRange' (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
+    removeEntityRange ctx entities |> ignore
 
 let toListAsync (dbset: #IQueryable<_>) = async {
     let! list = dbset.ToListAsync() |> Async.AwaitTask

--- a/src/EFCore.FSharp/DbContextHelpers.fs
+++ b/src/EFCore.FSharp/DbContextHelpers.fs
@@ -5,138 +5,145 @@ open EntityFrameworkCore.FSharp.Internal
 open Microsoft.EntityFrameworkCore
 open System.Threading.Tasks
 
-let private awaitValueTask (x: ValueTask<_>) = Async.AwaitTask (x.AsTask())
+let private awaitValueTask (x: ValueTask<_>) = Async.AwaitTask(x.AsTask())
 
-let findEntity<'a when 'a : not struct> (ctx: DbContext) (key: obj)=
-    ctx.Set<'a>().Find(key)
+let findEntity<'a when 'a: not struct> (ctx: DbContext) (key: obj) = ctx.Set<'a>().Find(key)
 
-let tryFindEntity<'a when 'a : not struct> (ctx: DbContext) (key: obj)=
+let tryFindEntity<'a when 'a: not struct> (ctx: DbContext) (key: obj) =
     let result = findEntity<'a> ctx key
     if isNull (box result) then None else Some result
 
-let findEntityAsync<'a when 'a : not struct> (ctx: DbContext) (key: obj) =
-    async {
-        return! ctx.Set<'a>().FindAsync(key) |> awaitValueTask
-    }
+let findEntityAsync<'a when 'a: not struct> (ctx: DbContext) (key: obj) =
+    async { return! ctx.Set<'a>().FindAsync(key) |> awaitValueTask }
 
-let findEntityTaskAsync<'a when 'a : not struct> (ctx: DbContext) (key: obj) =
-        ctx.Set<'a>().FindAsync(key)
-    
-let tryFindEntityAsync<'a when 'a : not struct> (ctx: DbContext) (key: obj) =
+let findEntityTaskAsync<'a when 'a: not struct> (ctx: DbContext) (key: obj) = ctx.Set<'a>().FindAsync(key)
+
+let tryFindEntityAsync<'a when 'a: not struct> (ctx: DbContext) (key: obj) =
     async {
         let! result = findEntityAsync<'a> ctx key
         return if isNull (box result) then None else Some result
     }
 
-let tryFindEntityTaskAsync<'a when 'a : not struct> (ctx: DbContext) (key: obj) =
-        let result = findEntityTaskAsync<'a> ctx key
-        result.AsTask().ContinueWith(
-            fun (t: Task<'a>) -> if isNull (box t.Result) then None else Some t.Result)
-        
+let tryFindEntityTaskAsync<'a when 'a: not struct> (ctx: DbContext) (key: obj) =
+    let result = findEntityTaskAsync<'a> ctx key
+
+    result
+        .AsTask()
+        .ContinueWith(fun (t: Task<'a>) -> if isNull (box t.Result) then None else Some t.Result)
+
 
 /// Helper method for saving an updated record type
-let updateEntity (ctx: DbContext) (key: 'a -> 'b) (entity : 'a when 'a : not struct) =
+let updateEntity (ctx: DbContext) (key: 'a -> 'b) (entity: 'a when 'a: not struct) =
     let currentEntity = findEntity<'a> ctx (key entity)
-    ctx.Entry(currentEntity).CurrentValues.SetValues(entity :> obj)
+
+    ctx
+        .Entry(currentEntity)
+        .CurrentValues.SetValues(entity :> obj)
+
     entity
 
-let updateEntityAsync (ctx: DbContext) (key: 'a -> obj) (entity : 'a when 'a : not struct) =
+let updateEntityAsync (ctx: DbContext) (key: 'a -> obj) (entity: 'a when 'a: not struct) =
     async { return updateEntity ctx key entity }
 
-let updateEntityRange  (ctx: DbContext) (key: 'a -> obj) (entities : 'a seq when 'a : not struct) =
-    entities |> Seq.map(fun e -> updateEntity ctx key e)
+let updateEntityRange (ctx: DbContext) (key: 'a -> obj) (entities: 'a seq when 'a: not struct) =
+    entities
+    |> Seq.map (fun e -> updateEntity ctx key e)
 
-let updateEntityRangeAsync  (ctx: DbContext) (key: 'a -> obj) (entities : 'a seq when 'a : not struct) =
+let updateEntityRangeAsync (ctx: DbContext) (key: 'a -> obj) (entities: 'a seq when 'a: not struct) =
     async { return updateEntityRange ctx key entities }
 
-let saveChanges (ctx: #DbContext) =
-    ctx.SaveChanges()
+let saveChanges' (ctx: #DbContext) = ctx.SaveChanges()
 
-let saveChanges' ctx  = saveChanges ctx |> ignore
+let saveChanges ctx = saveChanges' ctx |> ignore
 
-
-let saveChangesAsync (ctx: #DbContext) =
+let saveChangesAsync' (ctx: #DbContext) =
     async { return! ctx.SaveChangesAsync() |> Async.AwaitTask }
-let saveChangesAsync' ctx = saveChangesAsync ctx |> Async.Ignore
 
-let saveChangesTaskAsync (ctx: #DbContext) = ctx.SaveChangesAsync() 
-let saveChangesTaskAsync' ctx = saveChangesTaskAsync ctx :> Task
+let saveChangesAsync ctx = saveChangesAsync' ctx |> Async.Ignore
 
-let addEntity (ctx: #DbContext) (entity : 'a when 'a : not struct) =
-    ctx.Set<'a>().Add entity
+let saveChangesTaskAsync' (ctx: #DbContext) = ctx.SaveChangesAsync()
+let saveChangesTaskAsync ctx = saveChangesTaskAsync' ctx :> Task
 
-let addEntity' ctx entity =addEntity ctx entity |> ignore
+let addEntity' (ctx: #DbContext) (entity: 'a when 'a: not struct) = ctx.Set<'a>().Add entity
+
+let addEntity ctx entity = addEntity' ctx entity |> ignore
 
 
-let addEntityAsync (ctx: #DbContext) (entity : 'a when 'a : not struct) =
+let addEntityAsync' (ctx: #DbContext) (entity: 'a when 'a: not struct) =
+    async { return! ctx.Set<'a>().AddAsync(entity) |> awaitValueTask }
+
+let addEntityAsync ctx entity =
+    addEntityAsync' ctx entity |> Async.Ignore
+
+let addEntityTaskAsync' (ctx: #DbContext) (entity: 'a when 'a: not struct) = ctx.Set<'a>().AddAsync(entity).AsTask()
+let addEntityTaskAsync ctx entity = (addEntityTaskAsync' ctx entity) :> Task
+
+let addEntityRange' (ctx: #DbContext) (entities: 'a seq when 'a: not struct) = ctx.Set<'a>().AddRange entities
+
+let addEntityRange (ctx: #DbContext) (entities: 'a seq when 'a: not struct) = addEntityRange' ctx entities |> ignore
+
+let addEntityRangeAsync' (ctx: #DbContext) (entities: 'a seq when 'a: not struct) =
     async {
-        return! ctx.Set<'a>().AddAsync(entity) |> awaitValueTask
+        return!
+            ctx.Set<'a>().AddRangeAsync(entities)
+            |> Async.AwaitTask
     }
-let addEntityAsync' ctx entity  = addEntityAsync ctx entity |> Async.Ignore
 
-let addEntityTaskAsync (ctx: #DbContext) (entity : 'a when 'a : not struct) = ctx.Set<'a>().AddAsync(entity).AsTask()
-let addEntityTaskAsync' ctx entity  = (addEntityTaskAsync ctx entity) :> Task
+let addEntityRangeAsync (ctx: #DbContext) (entities: 'a seq when 'a: not struct) =
+    addEntityRangeAsync' ctx entities |> Async.Ignore
 
-let addEntityRange (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
-    ctx.Set<'a>().AddRange entities
+let attachEntity' (ctx: #DbContext) (entity: 'a when 'a: not struct) = ctx.Set<'a>().Attach entity
+let attachEntity (ctx: #DbContext) (entity: 'a when 'a: not struct) = attachEntity' ctx entity |> ignore
 
-let addEntityRange' (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
-    addEntityRange ctx entities |> ignore
+let attachEntityRange' (ctx: #DbContext) (entities: 'a seq when 'a: not struct) = ctx.Set<'a>().AttachRange(entities)
 
-let addEntityRangeAsync (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
+let attachEntityRange (ctx: #DbContext) (entities: 'a seq when 'a: not struct) =
+    attachEntityRange' ctx entities |> ignore
+
+let removeEntity' (ctx: #DbContext) (entity: 'a when 'a: not struct) = ctx.Set<'a>().Remove entity
+let removeEntity (ctx: #DbContext) (entity: 'a when 'a: not struct) = removeEntity' ctx entity |> ignore
+
+let removeEntityRange' (ctx: #DbContext) (entities: 'a seq when 'a: not struct) = ctx.Set<'a>().RemoveRange(entities)
+
+let removeEntityRange (ctx: #DbContext) (entities: 'a seq when 'a: not struct) =
+    removeEntityRange' ctx entities |> ignore
+
+let toListAsync (dbset: #IQueryable<_>) =
     async {
-        return! ctx.Set<'a>().AddRangeAsync(entities) |> Async.AwaitTask
+        let! list = dbset.ToListAsync() |> Async.AwaitTask
+        return list |> List.ofSeq
     }
-let addEntityRangeAsync' (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
-    addEntityRangeAsync ctx entities |> Async.Ignore
 
-let attachEntity (ctx: #DbContext) (entity : 'a when 'a : not struct) =
-    ctx.Set<'a>().Attach entity
-let attachEntity' (ctx: #DbContext) (entity : 'a when 'a : not struct) =
-    attachEntity ctx entity |> ignore
-
-let attachEntityRange (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
-    ctx.Set<'a>().AttachRange(entities)
-let attachEntityRange' (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
-    attachEntityRange ctx entities |> ignore
-
-let removeEntity (ctx: #DbContext) (entity : 'a when 'a : not struct) =
-    ctx.Set<'a>().Remove entity
-let removeEntity' (ctx: #DbContext) (entity : 'a when 'a : not struct) =
-    removeEntity ctx entity |> ignore
-
-let removeEntityRange (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
-    ctx.Set<'a>().RemoveRange(entities)
-let removeEntityRange' (ctx: #DbContext) (entities : 'a seq when 'a : not struct) =
-    removeEntityRange ctx entities |> ignore
-
-let toListAsync (dbset: #IQueryable<_>) = async {
-    let! list = dbset.ToListAsync() |> Async.AwaitTask
-    return list |> List.ofSeq
-}
-
-let toListTaskAsync (dbset: #IQueryable<_>) = dbset.ToListAsync() 
+let toListTaskAsync (dbset: #IQueryable<_>) = dbset.ToListAsync()
 
 
-let tryFirstAsync (dbset: #IQueryable<_>) = async {
-    let! ret = dbset.FirstOrDefaultAsync() |> Async.AwaitTask
-    return FSharpUtilities.OptionOfNullableObj ret
-}
+let tryFirstAsync (dbset: #IQueryable<_>) =
+    async {
+        let! ret = dbset.FirstOrDefaultAsync() |> Async.AwaitTask
+        return FSharpUtilities.OptionOfNullableObj ret
+    }
 
 let tryFirstTaskAsync dbset = tryFirstAsync dbset |> Async.StartAsTask
 
 
 let tryFirst (dbset: #IQueryable<_>) =
-    dbset.FirstOrDefault() |> FSharpUtilities.OptionOfNullableObj
+    dbset.FirstOrDefault()
+    |> FSharpUtilities.OptionOfNullableObj
 
-let tryFilterFirstAsync predicate (dbSet: #IQueryable<_>) = async {
-    let pred = FSharpUtilities.exprToLinq predicate
-    let! ret = dbSet.FirstOrDefaultAsync(predicate = pred) |> Async.AwaitTask
-    return FSharpUtilities.OptionOfNullableObj ret
-}
+let tryFilterFirstAsync predicate (dbSet: #IQueryable<_>) =
+    async {
+        let pred = FSharpUtilities.exprToLinq predicate
+
+        let! ret =
+            dbSet.FirstOrDefaultAsync(predicate = pred)
+            |> Async.AwaitTask
+
+        return FSharpUtilities.OptionOfNullableObj ret
+    }
 
 let tryFilterFirstTaskAsync predicate (dbSet: #IQueryable<_>) =
-    tryFilterFirstAsync predicate dbSet |> Async.StartAsTask
+    tryFilterFirstAsync predicate dbSet
+    |> Async.StartAsTask
 
 let tryFilterFirst predicate (dbSet: #IQueryable<_>) =
     let pred = FSharpUtilities.exprToLinq predicate
@@ -144,15 +151,22 @@ let tryFilterFirst predicate (dbSet: #IQueryable<_>) =
     FSharpUtilities.OptionOfNullableObj ret
 
 type IQueryable<'T> with
-    member this.TryFirstAsync () = this |> tryFirstAsync
-    member this.TryFirstTaskAsync () = this |> tryFirstTaskAsync
-    member this.TryFirst () = this |> tryFirst
-    member this.TryFirstAsync expr = async {
-        let! ret = this.FirstOrDefaultAsync(predicate = expr) |> Async.AwaitTask
-        return FSharpUtilities.OptionOfNullableObj ret
-    }
-    member this.TryFirstTaskAsync expr = this.TryFirstAsync(expr) |> Async.StartAsTask
+    member this.TryFirstAsync() = this |> tryFirstAsync
+    member this.TryFirstTaskAsync() = this |> tryFirstTaskAsync
+    member this.TryFirst() = this |> tryFirst
+
+    member this.TryFirstAsync expr =
+        async {
+            let! ret =
+                this.FirstOrDefaultAsync(predicate = expr)
+                |> Async.AwaitTask
+
+            return FSharpUtilities.OptionOfNullableObj ret
+        }
+
+    member this.TryFirstTaskAsync expr =
+        this.TryFirstAsync(expr) |> Async.StartAsTask
 
     member this.TryFirst expr =
         this.FirstOrDefault(predicate = expr)
-         |> FSharpUtilities.OptionOfNullableObj
+        |> FSharpUtilities.OptionOfNullableObj

--- a/src/EFCore.FSharp/Extensions/ModelBuilderExtensions.fs
+++ b/src/EFCore.FSharp/Extensions/ModelBuilderExtensions.fs
@@ -58,13 +58,12 @@ module Extensions =
     let useValueConverterForType (``type`` : Type) (converter : ValueConverter) (modelBuilder : ModelBuilder) =
         modelBuilder.UseValueConverterForType(``type``, converter)
 
-    type IRelationalDbContextOptionsBuilderInfrastructure with
-        member this.UseFSharpTypes() =
-            let coreOptionsBuilder = this.OptionsBuilder
 
+    type DbContextOptionsBuilder with
+        member this.UseFSharpTypes() =
             let extension =
-                let finded = coreOptionsBuilder.Options.FindExtension<FsharpTypeOptionsExtension>()
+                let finded = this.Options.FindExtension<FsharpTypeOptionsExtension>()
                 if (box finded) <> null then finded else FsharpTypeOptionsExtension()
 
-            (coreOptionsBuilder :> IDbContextOptionsBuilderInfrastructure).AddOrUpdateExtension(extension)
+            (this :> IDbContextOptionsBuilderInfrastructure).AddOrUpdateExtension(extension)
             this

--- a/tests/EFCore.FSharp.Tests/DbContextHelperTests.fs
+++ b/tests/EFCore.FSharp.Tests/DbContextHelperTests.fs
@@ -47,8 +47,8 @@ let DbContextHelperTests =
 
             use ctx = createContext ()
 
-            addEntity ctx original |> ignore
-            saveChanges ctx |> ignore
+            addEntity' ctx original 
+            saveChanges' ctx 
 
             let modified = { original with Title = "My New Title" }
 
@@ -125,8 +125,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity ctx blog |> ignore
-            saveChanges ctx |> ignore
+            addEntity' ctx blog 
+            saveChanges' ctx 
 
             let result = toListAsync ctx.Blogs |> Async.RunSynchronously
 
@@ -142,8 +142,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity ctx blog |> ignore
-            saveChanges ctx |> ignore
+            addEntity' ctx blog 
+            saveChanges' ctx 
 
             let result = tryFirstAsync ctx.Blogs |> Async.RunSynchronously
 
@@ -165,8 +165,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity ctx blog |> ignore
-            saveChanges ctx |> ignore
+            addEntity' ctx blog
+            saveChanges' ctx 
 
             let result = tryFirst ctx.Blogs
 

--- a/tests/EFCore.FSharp.Tests/DbContextHelperTests.fs
+++ b/tests/EFCore.FSharp.Tests/DbContextHelperTests.fs
@@ -47,8 +47,8 @@ let DbContextHelperTests =
 
             use ctx = createContext ()
 
-            addEntity' ctx original 
-            saveChanges' ctx 
+            addEntity ctx original
+            saveChanges ctx
 
             let modified = { original with Title = "My New Title" }
 
@@ -84,8 +84,8 @@ let DbContextHelperTests =
 
             let found =
                 async {
-                    let! _ = addEntityAsync ctx original
-                    let! _ = saveChangesAsync ctx
+                    do! addEntityAsync ctx original
+                    do! saveChangesAsync ctx
 
                     let modified = { original with Title = "My New Title" }
 
@@ -116,8 +116,8 @@ let DbContextHelperTests =
 
             let found =
                 async {
-                    let! _ = addEntityTaskAsync ctx original |> Async.AwaitTask
-                    let! _ = saveChangesTaskAsync ctx |> Async.AwaitTask
+                    do! addEntityTaskAsync ctx original |> Async.AwaitTask
+                    do! saveChangesTaskAsync ctx |> Async.AwaitTask
 
                     let modified = { original with Title = "My New Title" }
 
@@ -158,8 +158,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity' ctx blog 
-            saveChanges' ctx 
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = toListAsync ctx.Blogs |> Async.RunSynchronously
 
@@ -175,8 +175,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity' ctx blog 
-            saveChanges' ctx 
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = tryFirstAsync ctx.Blogs |> Async.RunSynchronously
 
@@ -198,8 +198,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity' ctx blog
-            saveChanges' ctx 
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = tryFirst ctx.Blogs
 
@@ -222,8 +222,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity ctx blog |> ignore
-            saveChanges ctx |> ignore
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = tryFilterFirstAsync
                              <@ fun x -> x.Id  = id @>
@@ -253,8 +253,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity ctx blog |> ignore
-            saveChanges ctx |> ignore
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = tryFilterFirst <@ fun x -> x.Id  = id @> ctx.Blogs
 
@@ -278,8 +278,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity ctx blog |> ignore
-            saveChanges ctx |> ignore
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = ctx.Blogs.TryFirstAsync() |> Async.RunSynchronously
 
@@ -302,8 +302,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity ctx blog |> ignore
-            saveChanges ctx |> ignore
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = ctx.Blogs.TryFirstTaskAsync() |> Async.AwaitTask |> Async.RunSynchronously
 
@@ -326,8 +326,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity ctx blog |> ignore
-            saveChanges ctx |> ignore
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = ctx.Blogs.TryFirst()
 
@@ -350,8 +350,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity ctx blog |> ignore
-            saveChanges ctx |> ignore
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = ctx.Blogs.TryFirstAsync(fun x -> x.Id  = id) |> Async.RunSynchronously
 
@@ -369,8 +369,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity' ctx blog 
-            saveChanges' ctx 
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = ctx.Blogs.TryFirstTaskAsync(fun x -> x.Id  = id) |> Async.AwaitTask |> Async.RunSynchronously
 
@@ -401,8 +401,8 @@ let DbSetTests =
                 Content = "My original content"
             }
 
-            addEntity ctx blog |> ignore
-            saveChanges ctx |> ignore
+            addEntity ctx blog
+            saveChanges ctx
 
             let result = ctx.Blogs.TryFirst(fun x -> x.Id  = id)
 

--- a/tests/EFCore.FSharp.Tests/Translations/OptionTranslationTests.fs
+++ b/tests/EFCore.FSharp.Tests/Translations/OptionTranslationTests.fs
@@ -24,9 +24,8 @@ type MyContext () =
     member this.Blogs with get() = this._blogs and set v = this._blogs <- v
 
     override _.OnConfiguring(options: DbContextOptionsBuilder) : unit =
-           options.UseSqlite(
-              $"Data Source={Guid.NewGuid().ToString()}.db",
-              (fun builder -> builder.UseFSharpTypes() |> ignore))
+           options.UseSqlite($"Data Source={Guid.NewGuid().ToString()}.db")
+                  .UseFSharpTypes()
            |> ignore
 
     override _.OnModelCreating builder =

--- a/tests/EFCore.FSharp.Tests/Translations/OptionTranslationTests.fs
+++ b/tests/EFCore.FSharp.Tests/Translations/OptionTranslationTests.fs
@@ -43,8 +43,8 @@ let blogWithoutContent = { Id = Guid.NewGuid(); Title = "My Title"; Content = No
 let saveBlogs ctx =
     [blogWithContent
      blogWithoutContent]
-    |> List.iter (addEntity ctx >> ignore)
-    saveChanges ctx |> ignore
+    |> List.iter (addEntity ctx)
+    saveChanges ctx
 
 [<Tests>]
 let OptionTranslationQueryTests =


### PR DESCRIPTION
- Changing where `UseFSharpTypes` extension is, so its easy to have it on the `DbContextOptionsBuilder`
- Adding unit return versions for some helper functions. this is because in most cases we don't care about the return of  `addEntity` or `saveChanges`, so have an option of this functions that return unit will help to not have a lot of `|> ignore` noise
- Task versions of async helpers: some people just use asp net or raw giraffe, which don't use the default F# `async` construct. so having the Task Async version of the most used functions seems like a good idea.
