### PR TITLE
Single case union support

### DIFF
--- a/docsSrc/How_Tos/Using_Single_Case_unions.md
+++ b/docsSrc/How_Tos/Using_Single_Case_unions.md
@@ -1,0 +1,97 @@
+# Single case union types (aka Simple types)
+It's common to use single case discriminated unions to meaningfully represent data values.
+But EF does not know anything about this kind of type. Luckily this repository has some ways to help you to deal with they.
+
+
+    [hide]
+    #r "Microsoft.EntityFrameworkCore.Sqlite.dll"
+
+    open System
+    open System.ComponentModel.DataAnnotations
+    open System.Linq
+    open Microsoft.EntityFrameworkCore
+    open EntityFrameworkCore.FSharp
+    open EntityFrameworkCore.FSharp.DbContextHelpers
+
+## Configuring
+
+We have two approaches to deal with single case union types which are a converter or an extension that searches for all Single Case Unions in your entities.
+
+
+
+```fsharp
+open EntityFrameworkCore.FSharp.Extensions
+
+type PostitiveInteger = PositiveInteger of int
+
+[<CLIMutable>]
+type Blog = {
+    [<Key>]
+    Id : Guid
+    Title : string
+    Votes: PositiveInteger
+}
+
+type MyContext () =
+    inherit DbContext()
+
+    [<DefaultValue>]
+    val mutable private _blogs : DbSet<Blog>
+    member this.Blogs with get() = this._blogs and set v = this._blogs <- v
+
+    override _.OnModelCreating builder =
+       
+        // setting manually each property
+        builder.Entity<Blog>()
+            .Property(fun x -> x.Votes)
+            .HasConversion(SingleCaseUnionConverter<int, PositiveInteger>())
+        |> ignore
+        
+        // OR
+        
+        // enables single clase unions for all entities
+        builder.RegisterSingleUnionCases() 
+
+    override _.OnConfiguring(options: DbContextOptionsBuilder) : unit =
+           options
+             .UseSqlite( "Data Source=dbName.db")
+             .UseFSharpTypes() // enable queries for F# types
+           |> ignore
+
+```
+
+## Querying
+
+You can query for equality without any problem
+
+
+```fsharp
+let blog =
+   query {
+       for blog in ctx.Blogs do
+       where (blog.Votes = PositiveInteger 10)
+       select blog
+       headOrDefault
+   }
+   
+ // or  
+let blog = ctx.Blogs.Where(fun b -> b.Votes = PositiveInteger 10).FirstOrDefault()
+```
+
+
+For querying with other types of operation you will need to unwrap the value inside the query
+
+```fsharp
+let blog =
+   query {
+       for blog in ctx.Blogs do
+       let (PositiveInteger votes) = blog.Votes
+       where (votes > 0)
+       select blog
+       headOrDefault
+   }
+```
+
+## Private Constructor
+
+This extension doesn't support private union case constructors. 

--- a/docsSrc/index.md
+++ b/docsSrc/index.md
@@ -36,6 +36,7 @@ This provides support for code-first and database-first use of EF Core in F#, in
         <a href="{{siteBaseUrl}}/How_Tos/Scaffold_As_Types.html" class="btn btn-primary">Scaffolding &amp; Code Generation</a>
         <a href="{{siteBaseUrl}}/How_Tos/Use_DbContextHelpers.html" class="btn btn-primary">Using DbContext Helpers</a>
         <a href="{{siteBaseUrl}}/How_Tos/Querying_Options.html" class="btn btn-primary">Querying option types</a>
+        <a href="{{siteBaseUrl}}/How_Tos/Using_Single_Case_unions.html" class="btn btn-primary">Single Case Unions</a>
       </div>
     </div>
   </div>

--- a/src/EFCore.FSharp/EFCore.FSharp.fsproj
+++ b/src/EFCore.FSharp/EFCore.FSharp.fsproj
@@ -32,6 +32,8 @@
     <Compile Include="Internal\FSharpUtilities.fs" />
     <Compile Include="ValueConverters\Converters.fs" />
     <Compile Include="Translations\OptionTranslation.fs" />
+    <Compile Include="Translations\SingleCaseUnionTranslation.fs" />
+    <Compile Include="Translations\Translation.fs" />
     <Compile Include="Scaffolding\FSharpDbContextGenerator.fs" />
     <Compile Include="Scaffolding\FSharpEntityTypeGenerator.fs" />
     <Compile Include="Scaffolding\Internal\FSharpModelGenerator.fs" />

--- a/src/EFCore.FSharp/Extensions/ModelBuilderExtensions.fs
+++ b/src/EFCore.FSharp/Extensions/ModelBuilderExtensions.fs
@@ -86,7 +86,7 @@ module Extensions =
     type DbContextOptionsBuilder with
         member this.UseFSharpTypes() =
             let extension =
-                let finded = coreOptionsBuilder.Options.FindExtension<FSharpTypeOptionsExtension>()
+                let finded = this.Options.FindExtension<FSharpTypeOptionsExtension>()
                 if (box finded) <> null then finded else FSharpTypeOptionsExtension()
 
 

--- a/src/EFCore.FSharp/Translations/SingleCaseUnionTranslation.fs
+++ b/src/EFCore.FSharp/Translations/SingleCaseUnionTranslation.fs
@@ -1,0 +1,13 @@
+module EntityFrameworkCore.FSharp.Translations.SingleCaseUnionTranslation
+
+open EntityFrameworkCore.FSharp
+open Microsoft.EntityFrameworkCore.Query
+
+let singleCaseUnionMemberTranslator(sqlExp: ISqlExpressionFactory ) = {
+    new IMemberTranslator with
+        member _.Translate(instance, member', returnType, loger) =
+           if SharedTypeExtensions.isSingleCaseUnion member'.DeclaringType then
+               sqlExp.Convert(instance, returnType) :> _
+           else
+               instance
+}

--- a/src/EFCore.FSharp/Translations/Translation.fs
+++ b/src/EFCore.FSharp/Translations/Translation.fs
@@ -1,0 +1,42 @@
+namespace EntityFrameworkCore.FSharp.Translations
+
+open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Query
+
+type FSharpMemberTranslatorPlugin(sqlExpressionFactory) =
+    interface IMemberTranslatorPlugin with
+        member _.Translators = seq {
+            OptionTranslation.optionMemberTranslator sqlExpressionFactory
+            SingleCaseUnionTranslation.singleCaseUnionMemberTranslator sqlExpressionFactory
+        }
+
+type FSharpMethodCallTranslatorPlugin(sqlExpressionFactory) =
+    interface IMethodCallTranslatorPlugin with
+        member _.Translators = seq {
+            OptionTranslation.optionMethodCallTranslator sqlExpressionFactory
+        }
+
+type ExtensionInfo(extension) =
+    inherit DbContextOptionsExtensionInfo(extension)
+        override _.IsDatabaseProvider = false
+
+        override _.GetServiceProviderHashCode() = 0L
+
+        override _.PopulateDebugInfo debugInfo =
+             debugInfo.["SqlServer: UseFSharp"] <- "1"
+
+        override _.LogFragment = "using FSharp types"
+
+type FSharpTypeOptionsExtension() =
+     interface IDbContextOptionsExtension with
+         member this.ApplyServices(services) =
+             EntityFrameworkRelationalServicesBuilder(services)
+                 .TryAddProviderSpecificServices(
+                     fun x ->
+                         x.TryAddSingletonEnumerable<IMemberTranslatorPlugin, FSharpMemberTranslatorPlugin>()
+                          .TryAddSingletonEnumerable<IMethodCallTranslatorPlugin, FSharpMethodCallTranslatorPlugin>()
+                         |> ignore)
+             |> ignore
+
+         member this.Info = ExtensionInfo(this :> IDbContextOptionsExtension) :> _
+         member this.Validate _ = ()

--- a/src/EFCore.FSharp/Utilities/SharedTypeExtensions.fs
+++ b/src/EFCore.FSharp/Utilities/SharedTypeExtensions.fs
@@ -3,6 +3,7 @@ namespace EntityFrameworkCore.FSharp
 open System
 open System.Reflection
 open System.Text
+open Microsoft.FSharp.Reflection
 
 module internal rec SharedTypeExtensions =
 
@@ -165,3 +166,15 @@ module internal rec SharedTypeExtensions =
         let sb = StringBuilder()
         processType t useFullName sb |> ignore
         sb.ToString()
+
+    let isSingleCaseUnion t =
+      FSharpType.IsUnion t
+      && FSharpType.GetUnionCases(t)
+         |> Array.length
+         |> ((=)1)
+
+    let unwrapSingleCaseUnion t =
+      let case = FSharpType.GetUnionCases(t)
+                 |> Array.exactlyOne
+      let field = case.GetFields() |> Array.head
+      field.PropertyType

--- a/src/EFCore.FSharp/ValueConverters/Converters.fs
+++ b/src/EFCore.FSharp/ValueConverters/Converters.fs
@@ -2,6 +2,7 @@ namespace EntityFrameworkCore.FSharp
 
 module Conversion =
 
+  open FSharp.Reflection
   open Microsoft.FSharp.Linq.RuntimeHelpers
   open System
   open System.Linq.Expressions
@@ -16,6 +17,20 @@ module Conversion =
     |> LeafExpressionConverter.QuotationToExpression
     |> unbox<Expression<Func<'T option, 'T>>>
 
+  let toSingleCaseUnion<'T, 'U> =
+    <@ Func<'T, 'U>(fun (x : 'T) -> FSharpValue.MakeUnion(FSharpType.GetUnionCases(typedefof<'U>) |> Array.exactlyOne, [|x :> obj|]) :?> 'U) @>
+    |> LeafExpressionConverter.QuotationToExpression
+    |> unbox<Expression<Func<'T, 'U>>>
+
+  let fromFromSingleCase<'T, 'U> =
+    <@ Func<'U, 'T>(fun (x : 'U) -> FSharpValue.GetUnionFields(x, x.GetType()) |> snd |> Seq.head :?> 'T) @>
+    |> LeafExpressionConverter.QuotationToExpression
+    |> unbox<Expression<Func<'U, 'T>>>
+
 type OptionConverter<'T> () =
   inherit Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<'T option, 'T>
             (Conversion.fromOption, Conversion.toOption)
+
+type SingleCaseUnionConverter<'T, 'U> () =
+  inherit Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<'U, 'T>
+            (Conversion.fromFromSingleCase, Conversion.toSingleCaseUnion)

--- a/tests/EFCore.FSharp.Tests/EFCore.FSharp.Tests.fsproj
+++ b/tests/EFCore.FSharp.Tests/EFCore.FSharp.Tests.fsproj
@@ -27,6 +27,7 @@
         <Compile Include="Scaffolding\Internal\FSharpDbContextGeneratorTest.fs" />
         <Compile Include="ValueConverters\ValueConvertersTest.fs" />
         <Compile Include="Translations\OptionTranslationTests.fs" />
+        <Compile Include="Translations\SingleCaseUnionTranslationTests.fs" />
         <Compile Include="DbContextHelperTests.fs" />
         <Compile Include="Main.fs" />
     </ItemGroup>

--- a/tests/EFCore.FSharp.Tests/Translations/SingleCaseUnionTranslationTests.fs
+++ b/tests/EFCore.FSharp.Tests/Translations/SingleCaseUnionTranslationTests.fs
@@ -26,9 +26,9 @@ type MyContext () =
     member this.Blogs with get() = this._blogs and set v = this._blogs <- v
 
     override _.OnConfiguring(options: DbContextOptionsBuilder) : unit =
-           options.UseSqlite(
-              $"Data Source={Guid.NewGuid().ToString()}.db",
-              (fun builder -> builder.UseFSharpTypes() |> ignore))
+           options
+               .UseSqlite($"Data Source={Guid.NewGuid().ToString()}.db")
+               .UseFSharpTypes()
            |> ignore
 
     override _.OnModelCreating builder =

--- a/tests/EFCore.FSharp.Tests/Translations/SingleCaseUnionTranslationTests.fs
+++ b/tests/EFCore.FSharp.Tests/Translations/SingleCaseUnionTranslationTests.fs
@@ -1,0 +1,102 @@
+module EFCore.FSharp.Tests.Translations.SingleCaseUnionTranslationTests
+
+open System
+open System.Linq
+open System.ComponentModel.DataAnnotations
+open EntityFrameworkCore.FSharp.DbContextHelpers
+open EntityFrameworkCore.FSharp.Extensions
+open Expecto
+open Microsoft.EntityFrameworkCore
+
+type PositiveInteger = PositiveInteger of int
+
+[<CLIMutable>]
+type Blog = {
+    [<Key>]
+    Id : Guid
+    Title : string
+    Votes : PositiveInteger
+}
+
+type MyContext () =
+    inherit DbContext()
+
+    [<DefaultValue>]
+    val mutable private _blogs : DbSet<Blog>
+    member this.Blogs with get() = this._blogs and set v = this._blogs <- v
+
+    override _.OnConfiguring(options: DbContextOptionsBuilder) : unit =
+           options.UseSqlite(
+              $"Data Source={Guid.NewGuid().ToString()}.db",
+              (fun builder -> builder.UseFSharpTypes() |> ignore))
+           |> ignore
+
+    override _.OnModelCreating builder =
+        builder.RegisterSingleUnionCases()
+
+let createContext () =
+    let ctx = new MyContext()
+    ctx.Database.EnsureDeleted() |> ignore
+    ctx.Database.EnsureCreated() |> ignore
+    ctx
+
+let blogWithVotes = { Id = Guid.NewGuid(); Title = "My Title"; Votes = PositiveInteger 10 }
+
+let saveBlogs ctx =
+    addEntity ctx blogWithVotes |> ignore
+    saveChanges ctx |> ignore
+
+[<Tests>]
+let OptionTranslationQueryTests =
+    testList "SingleCaseUnionTranslationTests with query" [
+
+        test "Filter votes property with exact value" {
+           use ctx = createContext ()
+           saveBlogs ctx
+
+           let blog =
+               query {
+                   for blog in ctx.Blogs do
+                   where (blog.Votes = PositiveInteger 10)
+                   select blog
+                   headOrDefault
+               }
+
+           Expect.equal blog blogWithVotes "Record in context should match"
+        }
+
+
+        test "Filter votes property with 'greater than' extracting property" {
+           use ctx = createContext ()
+           saveBlogs ctx
+
+           let blog =
+               query {
+                   for blog in ctx.Blogs do
+                   let (PositiveInteger votes) = blog.Votes
+                   where (votes > 0)
+                   select blog
+                   headOrDefault
+               }
+
+           Expect.equal blog blogWithVotes "Record in context should match"
+        }
+    ]
+
+
+[<Tests>]
+let OptionTranslationLinqMethodsTests =
+    testList "SingleCaseUnionTranslationTests with LINQ" [
+        test "Filter votes property with exact value" {
+           use ctx = createContext ()
+           saveBlogs ctx
+
+           let blog = ctx.Blogs.Where(fun b -> b.Votes = PositiveInteger 10).FirstOrDefault()
+
+           Expect.equal blog blogWithVotes "Record in context should match"
+        }
+    ]
+
+
+
+

--- a/tests/EFCore.FSharp.Tests/ValueConverters/ValueConvertersTest.fs
+++ b/tests/EFCore.FSharp.Tests/ValueConverters/ValueConvertersTest.fs
@@ -4,6 +4,8 @@ open System
 open EntityFrameworkCore.FSharp
 open Expecto
 
+type SingleCaseUnion = SingleCaseUnion of string
+
 [<Tests>]
 let ValueConvertersTest =
     testList "ValueConvertersTest" [
@@ -42,6 +44,24 @@ let ValueConvertersTest =
         test "Can create OptionConverter" {
             let oc = OptionConverter<string>()
 
+            Expect.isNotNull (box oc) "Should not be null"
+        }
+
+        test "string -> string SingleCaseUnion" {
+            let c = Conversion.toSingleCaseUnion<string, SingleCaseUnion>
+            let g = "test"
+            Expect.equal (c.Compile().Invoke(g)) (SingleCaseUnion g) "Should be equal"
+        }
+
+
+        test "string SingleCaseUnion -> string" {
+            let c = Conversion.fromFromSingleCase<string, SingleCaseUnion>
+            let g = "test"
+            Expect.equal (c.Compile().Invoke(SingleCaseUnion g)) g "Should be equal"
+        }
+
+        test "Can create SingleCaseUnionConverter" {
+            let oc = SingleCaseUnionConverter<string, SingleCaseUnion>()
             Expect.isNotNull (box oc) "Should not be null"
         }
     ]


### PR DESCRIPTION
## Proposed Changes

### Single case union types (aka Simple types)
It's common to use single case discriminated unions to meaningfully represent data values.
 EF does not know anything about this kind of type. This PR enables migration and mapping of single case discriminated unions

Example:
```fsharp
type PostitiveInteger = PositiveInteger of int

[<CLIMutable>]
type Blog = {
    [<Key>]
    Id : Guid
    Title : string
    Votes: PositiveInteger
}

type MyContext () =
    inherit DbContext()

    [<DefaultValue>]
    val mutable private _blogs : DbSet<Blog>
    member this.Blogs with get() = this._blogs and set v = this._blogs <- v

    override _.OnModelCreating builder =
        builder.RegisterSingleUnionCases()


let sample ctx = 
               query {
                   for blog in ctx.Blogs do
                   where (blog.Votes = PositiveInteger 10)
                   select blog
                   headOrDefault
               }
```



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] Build and tests pass locally
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added necessary documentation (if appropriate)

