### PR TITLE
Fix formatting of Nullable parameters

### DIFF
--- a/src/EFCore.FSharp/Migrations/Design/FSharpMigrationOperationGenerator.fs
+++ b/src/EFCore.FSharp/Migrations/Design/FSharpMigrationOperationGenerator.fs
@@ -41,9 +41,9 @@ type FSharpMigrationOperationGenerator (code : ICSharpHelper) =
 
         if nullableParameter.HasValue then
             let value = nullableParameter |> code.UnknownLiteral
-            let fmt = sprintf ", %s = Nullable(%s)" (sanitiseName name) value
+            let fmt = sprintf ",%s = Nullable(%s)" (sanitiseName name) value
 
-            sb |> append fmt
+            sb |> appendLine fmt
         else
             sb
 


### PR DESCRIPTION
## Proposed Changes

This fixes some weird formatting I saw in a generated migration file.

```fsharp
migrationBuilder.AddColumn<string>(
    name = "DisplayName"
    ,table = "SocialProfiles"
    ,``type`` = "nvarchar(100)"
    , maxLength = Nullable(100),nullable = true
    ) |> ignore
```

## Types of changes

What types of changes does your code introduce to EFCore.FSharp?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)