### PR TITLE
Helper methods should allow composite keys

### DIFF
--- a/src/EFCore.FSharp/Migrations/Design/FSharpMigrationOperationGenerator.fs
+++ b/src/EFCore.FSharp/Migrations/Design/FSharpMigrationOperationGenerator.fs
@@ -238,6 +238,7 @@ type FSharpMigrationOperationGenerator(code: ICSharpHelper) =
                     op.OldColumn.GetAnnotations() |> Seq.isEmpty
 
                 annotations hasNoOldAnnotations (op.GetAnnotations())
+
                 if not hasNoOldAnnotations then
                     oldAnnotations (op.OldColumn.GetAnnotations())
             }
@@ -254,6 +255,7 @@ type FSharpMigrationOperationGenerator(code: ICSharpHelper) =
                     op.OldDatabase.GetAnnotations() |> Seq.isEmpty
 
                 annotations hasNoOldAnnotations (op.GetAnnotations())
+
                 if not hasNoOldAnnotations then
                     oldAnnotations (op.OldDatabase.GetAnnotations())
             }
@@ -279,6 +281,7 @@ type FSharpMigrationOperationGenerator(code: ICSharpHelper) =
                     op.OldSequence.GetAnnotations() |> Seq.isEmpty
 
                 annotations hasNoOldAnnotations (op.GetAnnotations())
+
                 if not hasNoOldAnnotations then
                     oldAnnotations (op.OldSequence.GetAnnotations())
             }
@@ -296,6 +299,7 @@ type FSharpMigrationOperationGenerator(code: ICSharpHelper) =
                     op.OldTable.GetAnnotations() |> Seq.isEmpty
 
                 annotations hasNoOldAnnotations (op.GetAnnotations())
+
                 if not hasNoOldAnnotations then
                     oldAnnotations (op.OldTable.GetAnnotations())
             }


### PR DESCRIPTION
## Proposed Changes

Allow specifying an `obj []` or `obj list` of values for a composite key. This fixes #131 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The composite key must be an array, list or seq of type `obj` as a composite key may be made up of columns of different types.
Type inference can be used in this case rather than having to box each element, e.g.
```fsharp
let key : obj[] = [| 1; "2" |]
```