### PR TITLE
Fix quoting issue for defaultValue in migrations

### DIFF
--- a/src/EFCore.FSharp/Migrations/Design/FSharpMigrationOperationGenerator.fs
+++ b/src/EFCore.FSharp/Migrations/Design/FSharpMigrationOperationGenerator.fs
@@ -48,7 +48,7 @@ type FSharpMigrationOperationGenerator(code: ICSharpHelper) =
             None
 
     let writeOptionalParameter (name: string) (value: #obj) =
-        writeParameterIfTrue (notNull value) name (value |> code.UnknownLiteral |> sanitiseName)
+        writeParameterIfTrue (notNull value) name value
 
     let writeNullableParameterIfValue name (nullableParameter: Nullable<_>) =
 

--- a/tests/EFCore.FSharp.Tests/Migrations/Design/FSharpMigrationOperationGeneratorTest.fs
+++ b/tests/EFCore.FSharp.Tests/Migrations/Design/FSharpMigrationOperationGeneratorTest.fs
@@ -373,6 +373,29 @@ module FSharpMigrationOperationGeneratorTest =
                   Test<AddColumnOperation> op expected ``assert``
               }
 
+              test "AddColumnOperation defaultValue is not quoted" {
+                  let op =
+                      AddColumnOperation(Name = "Likes", Table = "Post", ClrType = typeof<int>, DefaultValue = 0)
+
+                  let expected =
+                      seq {
+                          "mb.AddColumn<int>("
+                          "    name = \"Likes\""
+                          "    ,table = \"Post\""
+                          "    ,nullable = false"
+                          "    ,defaultValue = 0"
+                          "    ) |> ignore"
+                      }
+                      |> join _eol
+
+                  let ``assert`` (o: AddColumnOperation) =
+                      Expect.equal o.Name "Likes" "Should be equal"
+                      Expect.equal o.Table "Post" "Should be equal"
+                      Expect.equal o.ClrType typeof<int> "Should be equal"
+
+                  Test<AddColumnOperation> op expected ``assert``
+              }
+
               test "CreateTableOperation optional args" {
                   let op =
                       CreateTableOperation(Name = "MyTable", Schema = "MySchema")


### PR DESCRIPTION
## Proposed Changes

- Add test for defaultValue in migrations being incorrectly quoted
- Only call code.UnknownLiteral once on an input

## Types of changes

What types of changes does your code introduce to EFCore.FSharp?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)